### PR TITLE
For select elements, compare values as strings and only when value is set

### DIFF
--- a/wp-forms-api/class-wp-forms-api.php
+++ b/wp-forms-api/class-wp-forms-api.php
@@ -743,7 +743,7 @@ class WP_Forms_API {
 			$option_atts = array( 'value' => $value );
 
 			if( $element['#multiple'] && in_array( $value, $element['#value'] ) ||
-					$value == $element['#value'] ) {
+					(string) $value === (string) $element['#value'] ) {
 				$option_atts['selected'] = "selected";
 			}
 

--- a/wp-forms-api/class-wp-forms-api.php
+++ b/wp-forms-api/class-wp-forms-api.php
@@ -601,7 +601,7 @@ class WP_Forms_API {
 				if( $element['#multiple'] ) {
 					$attrs['multiple'] = 'multiple';
 					$attrs['name'] .= '[]';
-					$element['#value'] = (array) $element['#value'];
+					$element['#value'] = array_map( 'strval', (array) $element['#value'] );
 				}
 
 				if( !$element['#required'] ) {
@@ -742,8 +742,9 @@ class WP_Forms_API {
 		foreach( $options as $value => $label ) {
 			$option_atts = array( 'value' => $value );
 
-			if( $element['#multiple'] && in_array( $value, $element['#value'] ) ||
-					(string) $value === (string) $element['#value'] ) {
+			if( isset( $element['#value'] ) &&
+				( ( $element['#multiple'] && in_array( (string) $value, $element['#value'] ) ) ||
+					(string) $value === (string) $element['#value'] ) ) {
 				$option_atts['selected'] = "selected";
 			}
 


### PR DESCRIPTION
...so a value of `null` (i.e. not set) will not select an option value of `''` or `0` and a value of `''` will not equate to an option value of `0`. Form values are inherently strings anyway.

Within `in_array`, even though `'0'` and `''` are both falsey, they are not considered equal when weakly compared (which is how `in_array` does it):

```
php > var_dump(!!'0');
bool(false)
php > var_dump(!!'');
bool(false)
php > var_dump(''=='0');
bool(false)
php > var_dump(''==0);
bool(true)
```

Thoughts?
