### PR TITLE
Add required script dependencies for Widgets admin page

### DIFF
--- a/wp-forms-api/class-wp-forms-api.php
+++ b/wp-forms-api/class-wp-forms-api.php
@@ -110,7 +110,7 @@ class WP_Forms_API {
 	 * @action init
 	 */
 	static function init() {
-		wp_register_script( 'wp-forms', self::url( 'wp-forms-api.js' ), array( 'jquery-ui-autocomplete', 'jquery-ui-sortable' ), 1, true );
+		wp_register_script( 'wp-forms', self::url( 'wp-forms-api.js' ), array( 'jquery-ui-autocomplete', 'jquery-ui-sortable', 'backbone', 'wp-util' ), 1, true );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'admin_enqueue' ) );
 		add_action( 'wp_ajax_wp_form_search_posts', array( __CLASS__, 'search_posts' ) );
 		add_action( 'wp_ajax_wp_form_search_terms', array( __CLASS__, 'search_terms' ) );


### PR DESCRIPTION
How to Reproduce Errors:

"Uncaught ReferenceError: Backbone is not defined" - Create widget with any input type utilizing the WP Forms API form fields. View Widget admin page.

"Uncaught TypeError: Cannot read property 'post' of undefined" - Create widget using 'post_select' input type. In the widget options form, start typing in name of post in the input field. 
