### PR TITLE
Process each item in a #type => multiple as its own form

### DIFF
--- a/wp-forms-api/class-wp-forms-api.php
+++ b/wp-forms-api/class-wp-forms-api.php
@@ -899,7 +899,10 @@ class WP_Forms_API {
 			$values[$element['#key']] = array();
 
 			if( isset( $input[$element['#key']] ) && is_array( $input[$element['#key']] ) ) {
-				$element['#value'] = $input[$element['#key']];
+				foreach( $input[$element['#key']] as $item ) {
+					self::process_form( $element['#multiple'], $value, $item );
+					$values[$element['#key']][] = $value;
+				}
 			}
 		}
 		// Or just pull the value from the input


### PR DESCRIPTION
This ensures that elements within a `multiple` field type are subject to the `wp_form_process_element*` filters, also.
