### PR TITLE
Modify how an initialized multi element is tracked

### DIFF
--- a/inc/wp-forms-api.js
+++ b/inc/wp-forms-api.js
@@ -15,11 +15,15 @@
 
 	// Multiple-list field
 	var initializeMultiple = function(context) {
-		$(context).find('.wp-form-multiple:not(.wp-form-initialized)').each(function() {
+		$(context).find('.wp-form-multiple').each(function() {
 			var $container = $(this)
 			  , $list = $container.find('.wp-form-multiple-list')
 			  , $tmpl = $container.find('.wp-form-multiple-template')
 			;
+			// do not re-initialize
+			if ($container.data('initialized')) {
+				return;
+			}
 
 			function reindex() {
 				// Note which elements are checked to prevent radio buttons from losing
@@ -71,7 +75,7 @@
 				});
 
 			// prevent double init which would register multiple click handlers
-			$container.addClass('wp-form-initialized');
+			$container.data('initialized',true);
 		});
 	}
 


### PR DESCRIPTION
- Use data instead of a classname because in some cases a rendered form
  may be used as a template for additional forms (as in with widget editor),
  so the classname would be copied over but the field really wouldn't be initialized.
  Data values are not copied in the same way.
