### PR TITLE
For the 'use labels as values' option, don't do this for the placeholder option

### DIFF
--- a/inc/class-wp-forms-api.php
+++ b/inc/class-wp-forms-api.php
@@ -716,7 +716,8 @@ class WP_Forms_API {
 
 		foreach( $options as $value => $label ) {
 			// ignore the value and use the label instead?
-			if ( $element['#labels_as_values'] && !is_array( $label ) ) {
+			// but not for a value of empty string, used for the placeholder option
+			if ( $element['#labels_as_values'] && !is_array( $label ) && $value !== '' ) {
 				$value = $label;
 			}
 			$option_atts = array( 'value' => $value );


### PR DESCRIPTION
- Let the value for that still be an empty string
