### PR TITLE
Make sure media scripts are enqueued

### DIFF
--- a/inc/class-wp-forms-api.php
+++ b/inc/class-wp-forms-api.php
@@ -197,6 +197,7 @@ class WP_Forms_API {
 	 * @action admin_enqueue_scripts
 	 */
 	static function admin_enqueue() {
+		wp_enqueue_media();
 		wp_enqueue_style( 'wp-forms', plugins_url( 'wp-forms-api.css', __FILE__ ) );
 	}
 


### PR DESCRIPTION
## Summary

If we are going to be rendering a form we need to make sure these assets are available, as forms can exist on other pages besides post edits.
## Relavant Ticket(s)
## Risk

[X] Trivial
[ ] Low
[ ] Medium
[ ] High
## How to Test
