### PR TITLE
Add #validators option, with validation result boolean in #valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WP Forms API
 
+[![Build Status](https://travis-ci.org/oomphinc/WP-Forms-API.svg?branch=master)](https://travis-ci.org/oomphinc/WP-Forms-API)
+
 <p align="center">
   <img width="490" height="275" src="https://github.com/bendoh/WP-Forms-API/raw/master/finally.jpg">
 </p>

--- a/inc/class-wp-forms-api.php
+++ b/inc/class-wp-forms-api.php
@@ -919,15 +919,20 @@ class WP_Forms_API {
 
 			// Validate element value and place result in #valid
 			if( !empty( $element['#validator'] ) ) {
-				$validators = (array) $element['#validator'];
+				if( is_callable( $element['#validator'] ) ) {
+					$validators = [ $element['#validator'] ];
+				}
+				else {
+					$validators = (array) $element['#validator'];
+				}
 
 				foreach( $validators as $validator ) {
-					if( is_callable( $element['#validator'] ) ) {
-						$element['#valid'] = call_user_func( $element['#validator'], $element );
+					if( is_callable( $validator ) ) {
+						$element['#valid'] = call_user_func( $validator, $element );
 					}
 					else {
 						// Assume it's a regular expression
-						$element['#valid'] = preg_match( $elenent['#validator'], $element );
+						$element['#valid'] = preg_match( $validator, $element );
 					}
 
 					// STOP! In the name of ... invalidity!

--- a/inc/class-wp-forms-api.php
+++ b/inc/class-wp-forms-api.php
@@ -77,6 +77,15 @@ class WP_Forms_API {
 		// Validation schema for this element. Can be an function or regular expression.
 		'#validator' => null,
 
+		// Validity state of this element.
+		'#valid' => true,
+
+		// The message to show after invalid values
+		'#invalid_message' => 'Invalid value',
+
+		// How many invalid elements were found in this form.
+		'#invalid_count' => 0,
+
 		// When #type=multiple, the index of this particular element in the set
 		'#index' => null,
 
@@ -690,6 +699,18 @@ class WP_Forms_API {
 			}
 		}
 
+		if( !$element['#valid'] ) ) {
+			$element['class'][] = 'wp-form-element-invalid';
+		}
+
+		if( $element['#validator'] ) {
+			// TODO: how to express this to markup so that it can be used in
+			// validation post-backs? Perhaps it's better to take the drupal approach
+			// and post the whole form, check output, and re-render it with validation
+			// messages.
+		}
+
+
 		$element = apply_filters( 'wp_form_element', $element );
 		$element = apply_filters( 'wp_form_element_key_' . $element['#key'], $element );
 
@@ -714,6 +735,11 @@ class WP_Forms_API {
 			$markup .= $element['#label_position'] == 'before' ? $label : '';
 			$markup .= self::make_tag( $element['#tag'], $element['#attrs'], $element['#content'] );
 			$markup .= $element['#label_position'] == 'after' ? $label : '';
+		}
+
+		// Add validation message if element value is not valid
+		if( !$element['#valid'] ) && $element['#invalid_message'] ) {
+			$markup .= self::make_tag( 'span', array( 'class' => 'wp-form-element-invalid-message' ), $element['#invalid_message'] );
 		}
 
 		if( $element['#description'] ) {
@@ -937,6 +963,7 @@ class WP_Forms_API {
 
 					// STOP! In the name of ... invalidity!
 					if( !$element['#valid'] ) {
+						$element['#form']['#invalid_count'] ++;
 						break;
 					}
 				}


### PR DESCRIPTION
## Summary

Adds support for '#validator' option, which can be a callable, a regular expression, or an array of both. Sets `#valid` boolean flag on all elements, which becomes `false` when the `#validator` expression fails.  The element value is not propagated when `#valid` is `false`. Addresses the question in #34.
## Risk
- [ ] Trivial
- [X] Low
- [ ] Medium
- [ ] High
## How to Test

... We really need to put together tests for this module!
