### PR TITLE
Set view input_name to name attribute of vanilla html input

### DIFF
--- a/inc/wp-forms-api.js
+++ b/inc/wp-forms-api.js
@@ -161,7 +161,7 @@
 				view.model.fetch();
 
 				// Don't save input name as part of the model as it should be invariant
-				view.input_name = this.name;
+				view.input_name = $(this).find('input').attr('name');
 				view.input_type = $(this).data('attachment-type');
 
 				view.render();


### PR DESCRIPTION
## Summary

Image field was not applying the name from the non-JS enabled input when applying media library JS for field. This caused image fields not have a name attribute when widget first added to sidebar.
## Relavant Ticket(s)
## Risk
- [ ] Trivial
- [x] Low
- [ ] Medium
- [ ] High
## How to Test

Image fields in widgets should store selected images when first added to a sidebar and saved for the first time
