### PR TITLE
Use model.get and model.set for input type & name

### DIFF
--- a/inc/wp-forms-api.js
+++ b/inc/wp-forms-api.js
@@ -155,7 +155,6 @@
 
 				view.model.fetch();
 
-				// Don't save input name as part of the model as it should be invariant
 				view.model.set('input_name', this.name || $(this).find('input').attr('name'));
 				view.model.set('input_type', $(this).data('attachment-type'));
 

--- a/inc/wp-forms-api.js
+++ b/inc/wp-forms-api.js
@@ -124,9 +124,6 @@
 			prepare: function() {
 				var data = this.model.toJSON();
 
-				data.input_name = this.model.get('input_name');
-				data.input_type = this.model.get('input_type');
-
 				return data;
 			},
 

--- a/inc/wp-forms-api.js
+++ b/inc/wp-forms-api.js
@@ -158,14 +158,8 @@
 				view.model.fetch();
 
 				// Don't save input name as part of the model as it should be invariant
-				if(typeof this.name === 'undefined'){
-					// New widgets added to sidebar after page load
-					view.model.set({'input_name': $(this).find('input').attr('name')});
-				} else {
-					// Widgets that exist at time of page load
-					view.model.set({'input_name': this.name});
-				}
-				view.model.set({'input_type': $(this).data('attachment-type')});
+				view.model.set('input_name', this.name || $(this).find('input').attr('name'));
+				view.model.set('input_type', $(this).data('attachment-type'));
 
 				view.render();
 

--- a/inc/wp-forms-api.js
+++ b/inc/wp-forms-api.js
@@ -122,9 +122,7 @@
 			},
 
 			prepare: function() {
-				var data = this.model.toJSON();
-
-				return data;
+				return this.model.toJSON();
 			},
 
 			update: function() {

--- a/inc/wp-forms-api.js
+++ b/inc/wp-forms-api.js
@@ -124,8 +124,8 @@
 			prepare: function() {
 				var data = this.model.toJSON();
 
-				data.input_name = this.input_name;
-				data.input_type = this.input_type;
+				data.input_name = this.model.get('input_name');
+				data.input_type = this.model.get('input_type');
 
 				return data;
 			},
@@ -161,8 +161,14 @@
 				view.model.fetch();
 
 				// Don't save input name as part of the model as it should be invariant
-				view.input_name = $(this).find('input').attr('name');
-				view.input_type = $(this).data('attachment-type');
+				if(typeof this.name === 'undefined'){
+					// New widgets added to sidebar after page load
+					view.model.set({'input_name': $(this).find('input').attr('name')});
+				} else {
+					// Widgets that exist at time of page load
+					view.model.set({'input_name': this.name});
+				}
+				view.model.set({'input_type': $(this).data('attachment-type')});
 
 				view.render();
 


### PR DESCRIPTION
## Summary

Previous behavior of `view.input_name = this.name` was correct for handling form setup on page load. `view.input_name = $(this).find('input').attr('name')` is correct for handling widgets added to sidebars after page load. This adds a check for whichever method is appropriate.

This change also switches to using `model.set()` and `model.get()` for these properties rather than setting extraneous properties on the view object.
## Relavant Ticket(s)
## Risk
- [ ] Trivial
- [X] Low
- [ ] Medium
- [ ] High
## How to Test

Image input ID fields should have a name attribute set both at time of page load (existing widgets) as well as when they are added to a sidebar after page load on the widgets screen.
