### PR TITLE
First swipe to get tinyMCEs in #multiple fields

### DIFF
--- a/inc/class-wp-forms-api.php
+++ b/inc/class-wp-forms-api.php
@@ -120,6 +120,8 @@ class WP_Forms_API {
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'admin_enqueue' ) );
 		add_action( 'wp_ajax_wp_form_search_posts', array( __CLASS__, 'search_posts' ) );
 		add_action( 'wp_ajax_wp_form_search_terms', array( __CLASS__, 'search_terms' ) );
+		add_action( 'wp_ajax_wp_form_get_mce_templates', array( __CLASS__, 'ajax_get_mce_templates' ) );
+
 		add_action( 'print_media_templates', array( __CLASS__, 'media_templates' ) );
 	}
 
@@ -922,6 +924,29 @@ class WP_Forms_API {
 		$element = apply_filters_ref_array( 'wp_form_process_element', array( &$element, &$values, &$input ) );
 
 		self::process_form( $element, $values_root, $input_root );
+	}
+
+	/**
+	 * Get WP editor templates for dynamically-inserted editors in #multiple fields
+	 *
+	 * @action wp_ajax_wp_form_get_mce_templates
+	 */
+	function ajax_get_mce_templates() {
+		$results = array();
+		$bodies = filter_input( INPUT_POST, 'content', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );
+
+		foreach ( $bodies as $id => $body ) {
+			ob_start();
+			$lines = preg_split( '/$/m', $body );
+
+			wp_editor( $body, $id, array(
+				'textarea_name' => $id,
+				'textarea_rows' => count( $lines ),
+			)  );
+			$results[$id] = ob_get_clean();
+		}
+
+		wp_send_json_success( $results );
 	}
 
 	/**

--- a/inc/wp-forms-api.js
+++ b/inc/wp-forms-api.js
@@ -13,6 +13,41 @@
 		},
 	});
 
+	function loadMCETemplates(content, editor) {
+		wp.ajax.post('wp_form_get_mce_templates', {
+			content: content,
+			type: getUserSetting('editor')
+		}).done(function(result) {
+			_.each(result, function(html, id) {
+				var $box = $('#' + id);
+
+				$box.html(html);
+
+				if(editor) {
+					$box.find('.wp-editor-wrap').addClass(editor == 'html' ? 'html-active' : 'tmce-active');
+				}
+
+				var config = _.clone(tinyMCEPreInit.mceInit.content);
+
+				config.selector = id;
+				config.toolbar1 = ['bold', 'italic', 'underline', 'blockquote', 'strikethrough', 'bullist', 'numlist', 'alignleft', 'aligncenter', 'alignright', 'undo', 'redo', 'link', 'unlink'].join(',');
+				config.toolbar2 = config.toolbar3 = config.toolbar4 = '';
+				config.plugins = ['colorpicker', 'lists', 'fullscreen', 'image', 'wordpress', 'wpeditimage', 'wplink' ].join(',');
+				config.cache_suffix += '-' + id;
+
+				quicktags(id);
+
+				tinyMCEPreInit.mceInit[id] = config;
+
+				if(editor != 'html') {
+					tinymce.init(config);
+				}
+			});
+
+			QTags._buttonsInit();
+		});
+	}
+
 	// Multiple-list field
 	var initializeMultiple = function(context) {
 		$(context).find('.wp-form-multiple').each(function() {
@@ -20,6 +55,7 @@
 			  , $list = $container.find('.wp-form-multiple-list')
 			  , $tmpl = $container.find('.wp-form-multiple-template')
 			;
+
 			// do not re-initialize
 			if ($container.data('initialized')) {
 				return;
@@ -75,7 +111,7 @@
 				});
 
 			// prevent double init which would register multiple click handlers
-			$container.data('initialized',true);
+			$container.data('initialized', true);
 		});
 	}
 

--- a/inc/wp-forms-api.js
+++ b/inc/wp-forms-api.js
@@ -13,13 +13,12 @@
 		},
 	});
 
-	function loadMCETemplates(content, editor) {
+	var loadMCETemplates = function(content, editor) {
 		wp.ajax.post('wp_form_get_mce_templates', {
-			content: content,
-			type: getUserSetting('editor')
+			content: content
 		}).done(function(result) {
 			_.each(result, function(html, id) {
-				var $box = $('#' + id);
+				var $box = $('#' + id).parent();
 
 				$box.html(html);
 
@@ -27,7 +26,7 @@
 					$box.find('.wp-editor-wrap').addClass(editor == 'html' ? 'html-active' : 'tmce-active');
 				}
 
-				var config = _.clone(tinyMCEPreInit.mceInit.content);
+				var config = _.clone(tinyMCEPreInit.mceInit.wpfapiTemplate);
 
 				config.selector = id;
 				config.toolbar1 = ['bold', 'italic', 'underline', 'blockquote', 'strikethrough', 'bullist', 'numlist', 'alignleft', 'aligncenter', 'alignright', 'undo', 'redo', 'link', 'unlink'].join(',');
@@ -46,6 +45,18 @@
 
 			QTags._buttonsInit();
 		});
+	}
+
+	// Any dynamically-inserted MCE containers
+	var initializeMCE = function(context) {
+		var request = {};
+
+		// Build up a query to get templates from AJAX
+		$(context).find('.wp-form-type-mce textarea').each(function() {
+			request[this.id] = this.value;
+		});
+
+		loadMCETemplates(request, 'html');
 	}
 
 	// Multiple-list field
@@ -98,6 +109,8 @@
 					initialize($html);
 
 					$list.append($html);
+
+					initializeMCE($html);
 				})
 
 				// Remove an item item on click

--- a/tests/test-wp-forms-api.php
+++ b/tests/test-wp-forms-api.php
@@ -10,4 +10,9 @@ class WP_Forms_API_Test extends WP_UnitTestCase {
 		$this->assertContains( 'type="text"', $html );
 		$this->assertContains( 'name="text-input"', $html );
 	}
+
+	function test_multiple_mces() {
+
+	}
+
 }


### PR DESCRIPTION
## Summary

Addresses issue #38 – Allow for `#multiple` fields to contain `mce`-type fields, which involves some JavaScript hoop-jumping-through.
## Relavant Ticket(s)

Issue #38 
