### PR TITLE
Updates handling of checkbox data in multiple fields

### DIFF
--- a/inc/class-wp-forms-api.php
+++ b/inc/class-wp-forms-api.php
@@ -523,10 +523,7 @@ class WP_Forms_API {
 				$element['#content'] = null;
 				$element['#label_position'] = 'after';
 
-				// $element['#value'] is likely a string, $element['#checked'] may be a boolean,
-				// as we are not concerned with the actual value, simply confirm that both keys'
-				// values are truthy
-				if ( $element['#value'] && $element['#checked'] ) {
+				if ( $element['#value'] === $element['#checked'] ) {
 					$attrs['checked'] = 'checked';
 				}
 

--- a/inc/class-wp-forms-api.php
+++ b/inc/class-wp-forms-api.php
@@ -523,7 +523,10 @@ class WP_Forms_API {
 				$element['#content'] = null;
 				$element['#label_position'] = 'after';
 
-				if ( $element['#value'] === $element['#checked'] ) {
+				// $element['#value'] is likely a string, $element['#checked'] may be a boolean,
+				// as we are not concerned with the actual value, simply confirm that both keys'
+				// values are truthy
+				if ( $element['#value'] && $element['#checked'] ) {
 					$attrs['checked'] = 'checked';
 				}
 
@@ -896,6 +899,11 @@ class WP_Forms_API {
 				foreach( $input[$element['#key']] as $item ) {
 					self::process_form( $element['#multiple'], $value, $item );
 					$values[$element['#key']][] = $value;
+
+					// Unset $value so it does not keep data from a previous iteration
+					// this caused all unchecked checkboxes following a checked input
+					// in a multiple field to store as checked on save.
+					unset( $value );
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Bug in how checkbox inputs in multiple fields are stored. Any checkboxes following the first checked one are saved as being checked. This PR unsets the value of the current field after handling it so the next checkbox doesn't pick it up mistakenly. Also updates logic for form render to properly check previously selected checkboxes
## Risk
- [ ] Trivial
- [ ] Low
- [X] Medium
- [ ] High
## How to Test

Selecting a checkbox input in the middle of a multiple list should not also store the same field in following rows as checked as well when they are not manually checked. Fields stored as checked should render as checked on subsequent page loads.
