### PR TITLE
Ensure checkbox values are not empty when processing elements

### DIFF
--- a/inc/class-wp-forms-api.php
+++ b/inc/class-wp-forms-api.php
@@ -878,7 +878,7 @@ class WP_Forms_API {
 		// Process checkbox by presence of #key, using the #checked value
 		// If not key is not set or is empty, set value to false
 		else if ( $element['#type'] === 'checkbox' ) {
-			if ( isset( $input[$element['#key']] ) && !empty( $input[$element['#key']] ) ) {
+			if ( !empty( $input[$element['#key']] ) ) {
 				$element['#value'] = $element['#checked'];
 			} else {
 				$element['#value'] = false;

--- a/inc/class-wp-forms-api.php
+++ b/inc/class-wp-forms-api.php
@@ -876,9 +876,13 @@ class WP_Forms_API {
 			$element['#value'] = isset( $input[$element['#key']] ) && $input[$element['#key']];
 		}
 		// Process checkbox by presence of #key, using the #checked value
-		// If not key is not set, set value to false
+		// If not key is not set or is empty, set value to false
 		else if ( $element['#type'] === 'checkbox' ) {
-			$element['#value'] = isset( $input[$element['#key']] ) ? $element['#checked'] : false;
+			if ( isset( $input[$element['#key']] ) && !empty( $input[$element['#key']] ) ) {
+				$element['#value'] = $element['#checked'];
+			} else {
+				$element['#value'] = false;
+			}
 		}
 		// Munge composite elements
 		else if( $element['#type'] == 'composite' ) {


### PR DESCRIPTION
## Summary

There are cases where a checkbox value in process_element() is set but empty when the field is left unchecked. The current isset() only check is allowing unchecked boxes behave as if they were checked in some cases when using process_form()

This isn't a certainty, however it seems like this happens with forms in widgets, where the current values are pulled from the database as serialized data, and would include values set to false for boolean data, whereas processing forms submitted via $_POST would not include the unchecked field at all.
## Risk
- [ ] Trivial
- [x] Low
- [ ] Medium
- [ ] High
## How to Test

Forms should recognize saved unchecked fields as false when retrieving values via process_form(), for both widgets as well as standard forms submitted via $_POST
