### PR TITLE
Sets various selected image data to null instead of clearing model entirely

### DIFF
--- a/inc/wp-forms-api.js
+++ b/inc/wp-forms-api.js
@@ -110,7 +110,14 @@
 			},
 
 			removeAttachment: function() {
-				this.model.clear();
+				// Don't clear the model entirely, just the set values
+				this.model.set({
+					id: null,
+					title: null,
+					link: null,
+					url: null,
+					editLink: null
+				});
 			},
 
 			initialize: function() {


### PR DESCRIPTION
## Summary

Currently using the X to unset an image field clears the entire model. The name attribute of the field containing the image ID for storage is part of the model. This PR updates the removeAttachment method to only unset the attributes related to the selected image.
## Risk
- [ ] Trivial
- [x] Low
- [ ] Medium
- [ ] High
