### PR TITLE
Fix empty name attribute after manually entering attachment ID

### DIFF
--- a/inc/wp-forms-api.js
+++ b/inc/wp-forms-api.js
@@ -136,10 +136,16 @@
 				var view = this,
 					$field = this.$el.find('.wp-form-attachment-id'),
 					attachmentId = $field.val(),
-					attachment = media.model.Attachment.get(attachmentId).clone();
+					attachment = media.model.Attachment.get(attachmentId).clone(),
+					inputName = view.model.get('input_name'),
+					inputType = view.model.get('input_type');
 
 				view.model.clear({ silent: true });
-				view.model.set({ id: attachmentId });
+				view.model.set({
+					id: attachmentId,
+					input_name: inputName,
+					input_type: inputType
+				});
 
 				$field.addClass('ui-dirty');
 


### PR DESCRIPTION
## Summary

This commit fixes a bug when manually entering the attachment ID in image fields. The input's name attribute gets set to an empty value which then prevents the image field from being saved correctly.
## Risk
- [ ] Trivial
- [x] Low
- [ ] Medium
- [ ] High
## How to Test
